### PR TITLE
typos: mostly minor, one account alias

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,34 +73,34 @@ func (cl *Client) GetDatacenterList() (res []*datacenters.GetDatacenterListRes, 
 
 func (cl *Client) GetStatus(statusId string) (res *queue.GetStatusRes, err error) {
 	res = &queue.GetStatusRes{}
-	err = cl.executeRequest("GET", fmt.Sprintf("operations/{acctAlias}/status/%s", statusId), nil, res)
+	err = cl.executeRequest("GET", fmt.Sprintf("operations/{accountAlias}/status/%s", statusId), nil, res)
 	return
 }
 
-func (cl *Client) DeleteAntiAfinityPolicy(policyId string) (err error) {
+func (cl *Client) DeleteAntiAffinityPolicy(policyId string) (err error) {
 	err = cl.executeRequest("DELETE", fmt.Sprintf("antiAffinityPolicies/{accountAlias}/%S", policyId), nil, nil)
 	return
 }
 
-func (cl *Client) UpdateAntiAfinityPolicy(policyId string, req *account.UpdateAntiAfinityPolicyReq) (res *account.AntiAfinityPolicyRes, err error) {
-	res = &account.AntiAfinityPolicyRes{}
+func (cl *Client) UpdateAntiAffinityPolicy(policyId string, req *account.UpdateAntiAffinityPolicyReq) (res *account.AntiAffinityPolicyRes, err error) {
+	res = &account.AntiAffinityPolicyRes{}
 	err = cl.executeRequest("PUT", fmt.Sprintf("antiAffinityPolicies/{accountAlias}/%S", policyId), req, res)
 	return
 }
 
-func (cl *Client) CreateAntiAfinityPolicy(policyId string, req *account.CreateAntiAfinityPolicyReq) (res *account.AntiAfinityPolicyRes, err error) {
-	res = &account.AntiAfinityPolicyRes{}
+func (cl *Client) CreateAntiAffinityPolicy(policyId string, req *account.CreateAntiAffinityPolicyReq) (res *account.AntiAffinityPolicyRes, err error) {
+	res = &account.AntiAffinityPolicyRes{}
 	err = cl.executeRequest("PUT", fmt.Sprintf("antiAffinityPolicies/{accountAlias}/%S", policyId), req, res)
 	return
 }
 
-func (cl *Client) GetAntiAfinityPolicy(policyId string) (res *account.AntiAfinityPolicyRes, err error) {
-	res = &account.AntiAfinityPolicyRes{}
+func (cl *Client) GetAntiAffinityPolicy(policyId string) (res *account.AntiAffinityPolicyRes, err error) {
+	res = &account.AntiAffinityPolicyRes{}
 	err = cl.executeRequest("PUT", fmt.Sprintf("antiAffinityPolicies/{accountAlias}/%S", policyId), nil, res)
 	return
 }
 
-func (cl *Client) GetAntiAfinityPolicies() (res []*account.AntiAfinityPolicyRes, err error) {
+func (cl *Client) GetAntiAffinityPolicies() (res []*account.AntiAffinityPolicyRes, err error) {
 	err = cl.executeRequest("PUT", "antiAffinityPolicies/{accountAlias}/%S", nil, &res)
 	return
 }

--- a/client.go
+++ b/client.go
@@ -54,20 +54,36 @@ func (cl *Client) SetLogger(logger *log.Logger) (err error) {
 	return
 }
 
+/**
+ * Gets the list of capabilities that a specific data center supports for a given account,
+ * including the deployable networks, OS templates, and whether features like premium storage
+ * and shared load balancer configuration are available.
+ * This operation is helpful for retrieving network identifiers and OS template names to use when creating a server.
+ */
 func (cl *Client) GetDatacenterDeploymentCapabilities(datacenter string) (res *datacenters.GetDatacenterDeploymentCapabilitiesRes, err error) {
 	res = &datacenters.GetDatacenterDeploymentCapabilitiesRes{}
 	err = cl.executeRequest("GET", fmt.Sprintf("datacenters/{accountAlias}/%s/deploymentCapabilities", datacenter), nil, res)
 	return
 }
 
-func (cl *Client) GetDatacenterGroup(datacenter string, groupLinks bool) (res *datacenters.GetDatacenterGroupRes, err error) {
-	res = &datacenters.GetDatacenterGroupRes{}
-	err = cl.executeRequest("GET", fmt.Sprintf("datacenters/{accountAlias}/%s?groupLinks=%t", datacenter, groupLinks), nil, res)
+/**
+ * Gets the list of data centers that a given account has access to.
+ * Use this API operation when you need the list of data center names and codes that you have access to.
+ * Using that list of data centers, you can then query for the root group, and all the child groups in an entire data center.
+ */
+func (cl *Client) GetDatacenterList() (res []*datacenters.GetDatacenterListRes, err error) {
+	err = cl.executeRequest("GET", "datacenters/{accountAlias}", nil, &res)
 	return
 }
 
-func (cl *Client) GetDatacenterList() (res []*datacenters.GetDatacenterListRes, err error) {
-	err = cl.executeRequest("GET", "datacenters/{accountAlias}", nil, &res)
+/**
+ * Gets the details of a specific data center.
+ * Use this API operation when you want to discover the name of the root hardware group for a data center.
+ * Once you have that group alias, you can issue a secondary query to retrieve the entire group hierarchy for a given data center.
+ */
+func (cl *Client) GetDatacenter(datacenter string, groupLinks bool) (res *datacenters.GetDatacenterRes, err error) {
+	res = &datacenters.GetDatacenterRes{}
+	err = cl.executeRequest("GET", fmt.Sprintf("datacenters/{accountAlias}/%s?groupLinks=%t", datacenter, groupLinks), nil, res)
 	return
 }
 

--- a/client.go
+++ b/client.go
@@ -62,7 +62,7 @@ func (cl *Client) GetDatacenterDeploymentCapabilities(datacenter string) (res *d
 
 func (cl *Client) GetDatacenterGroup(datacenter string, groupLinks bool) (res *datacenters.GetDatacenterGroupRes, err error) {
 	res = &datacenters.GetDatacenterGroupRes{}
-	err = cl.executeRequest("GET", fmt.Sprintf("datacenters/{accountAlias}/%s?groupLinks=%t", datacenter, groupLinks), nil, &res)
+	err = cl.executeRequest("GET", fmt.Sprintf("datacenters/{accountAlias}/%s?groupLinks=%t", datacenter, groupLinks), nil, res)
 	return
 }
 

--- a/client.go
+++ b/client.go
@@ -245,5 +245,5 @@ func (cl *Client) executeRequest(verb string, url string, reqModel interface{}, 
 		err = fmt.Errorf("The client is not initialized. You should call Connect method first.")
 		return
 	}
-	return cl.connection.ExecuteRequest(verb, url, reqModel, resModel)
+	return cl.connection.ExecuteRequest(verb, API_VERSION + url, reqModel, resModel)
 }

--- a/connection.go
+++ b/connection.go
@@ -16,7 +16,7 @@ import (
 )
 
 //this made a variable instead of a constant for testing purpoises
-var BaseUrl = "https://api.tier3.com"
+var BaseUrl = "https://api.ctl.io"
 
 const (
 	API_VERSION = "/v2/"

--- a/connection.go
+++ b/connection.go
@@ -100,6 +100,9 @@ func (cn *connection) processResponse(res *http.Response, resModel interface{}) 
 		if err != nil {
 			cn.logger.Printf(err.Error())
 		}
+		// FIXME: this is not descriptive enough
+		// FIXME: check if body contains JSON { "message": <descriptive text> }
+		//        and return that
 		return &errors.ApiError{
 			StatusCode:  res.StatusCode,
 			ApiResponse: resModel,

--- a/connection.go
+++ b/connection.go
@@ -37,7 +37,7 @@ func newConnection(username string, password string, logger *log.Logger) (cn *co
 	}
 	cn.bearerToken = loginRes.BearerToken
 	cn.accountAlias = loginRes.AccountAlias
-	cn.logger.Printf("Updateing connection. Bearer: %s, Alias: %s", cn.bearerToken, cn.accountAlias)
+	cn.logger.Printf("Updating connection. Bearer: %s, Alias: %s", cn.bearerToken, cn.accountAlias)
 	return
 }
 

--- a/connection.go
+++ b/connection.go
@@ -16,7 +16,11 @@ import (
 )
 
 //this made a variable instead of a constant for testing purpoises
-var BaseUrl = "https://api.tier3.com/v2/"
+var BaseUrl = "https://api.tier3.com"
+
+const (
+	API_VERSION = "/v2/"
+)
 
 type connection struct {
 	bearerToken  string
@@ -31,7 +35,7 @@ func newConnection(username string, password string, logger *log.Logger) (cn *co
 	cn.logger.Printf("Creating new connection. Username: %s", username)
 	loginReq := &authentication.LoginReq{username, password}
 	loginRes := &authentication.LoginRes{}
-	err = cn.ExecuteRequest("POST", "authentication/login", loginReq, loginRes)
+	err = cn.ExecuteRequest("POST", API_VERSION + "authentication/login", loginReq, loginRes)
 	if err != nil {
 		return
 	}

--- a/models/account/anti_afinity_policy_res.go
+++ b/models/account/anti_afinity_policy_res.go
@@ -29,11 +29,11 @@ func (r *AntiAffinityPolicyRes) SetConnection(connection base.Connection) {
 }
 
 func (r *AntiAffinityPolicyRes) Self() (res *AntiAffinityPolicyRes, err error) {
-	err = models.ResolveLink(r, "self", res)
+	err = models.ResolveLink(r, "self", "GET", res)
 	return
 }
 
 func (r *AntiAffinityPolicyRes) Server() (res *servers.GetServerRes, err error) {
-	err = models.ResolveLink(r, "server", res)
+	err = models.ResolveLink(r, "server", "GET", res)
 	return
 }

--- a/models/account/anti_afinity_policy_res.go
+++ b/models/account/anti_afinity_policy_res.go
@@ -6,7 +6,7 @@ import (
 	"github.com/s-matyukevich/centurylink_sdk/models/servers"
 )
 
-type AntiAfinityPolicyRes struct {
+type AntiAffinityPolicyRes struct {
 	Connection base.Connection
 	Id         string
 	Name       string
@@ -14,26 +14,26 @@ type AntiAfinityPolicyRes struct {
 	Links      []models.Link
 }
 
-var _ models.LinkModel = (*AntiAfinityPolicyRes)(nil)
+var _ models.LinkModel = (*AntiAffinityPolicyRes)(nil)
 
-func (r *AntiAfinityPolicyRes) GetLinks() []models.Link {
+func (r *AntiAffinityPolicyRes) GetLinks() []models.Link {
 	return r.Links
 }
 
-func (r *AntiAfinityPolicyRes) GetConnection() base.Connection {
+func (r *AntiAffinityPolicyRes) GetConnection() base.Connection {
 	return r.Connection
 }
 
-func (r *AntiAfinityPolicyRes) SetConnection(connection base.Connection) {
+func (r *AntiAffinityPolicyRes) SetConnection(connection base.Connection) {
 	r.Connection = connection
 }
 
-func (r *AntiAfinityPolicyRes) Self() (res *AntiAfinityPolicyRes, err error) {
+func (r *AntiAffinityPolicyRes) Self() (res *AntiAffinityPolicyRes, err error) {
 	err = models.ResolveLink(r, "self", res)
 	return
 }
 
-func (r *AntiAfinityPolicyRes) Server() (res *servers.GetServerRes, err error) {
+func (r *AntiAffinityPolicyRes) Server() (res *servers.GetServerRes, err error) {
 	err = models.ResolveLink(r, "server", res)
 	return
 }

--- a/models/account/create_anti_afinity_policy.go
+++ b/models/account/create_anti_afinity_policy.go
@@ -1,6 +1,6 @@
 package account
 
-type CreateAntiAfinityPolicyReq struct {
+type CreateAntiAffinityPolicyReq struct {
 	Name     string
 	Location string
 }

--- a/models/account/update_anti_afinity_policy.go
+++ b/models/account/update_anti_afinity_policy.go
@@ -1,5 +1,5 @@
 package account
 
-type UpdateAntiAfinityPolicyReq struct {
+type UpdateAntiAffinityPolicyReq struct {
 	Name string
 }

--- a/models/datacenters/get_datacenter_deployment_capabilities.go
+++ b/models/datacenters/get_datacenter_deployment_capabilities.go
@@ -1,24 +1,78 @@
 package datacenters
 
 type GetDatacenterDeploymentCapabilitiesRes struct {
-	SupportsPremiumStorage     bool
-	SupportsSharedLoadBalancer bool
-	DeployableNetworks         []DeployableNetworks
-	Templates                  []Templates
+	// Whether or not this data center provides support for servers with premium storage
+	SupportsPremiumStorage		bool			`json: "supportsPremiumStorage"`
+
+	// Whether or not this data center provides support for shared load balancer configuration
+	SupportsSharedLoadBalancer	bool			`json: "supportsSharedLoadBalancer"`
+
+	// Whether or not this data center provides support for  Whether or not this data center
+	// provides support for provisioning bare metal servers
+	SupportsBareMetalServers	bool			`json: "supportsBareMetalServers"`
+
+	// Collection of networks that can be used for deploying servers
+	DeployableNetworks		[]DeployableNetworks	`json: "deployableNetworks"`
+
+	// Collection of available templates in the data center that can be used to create servers
+	Templates			[]Templates		`json: "templates"`
+
+	// Collection of available OS types that can be imported as virtual machines
+	ImportableOSTypes		[]ImportableOsType	`json: "importableOSTypes"`
+
+	// FIXME: the following appear in the output but are undocumented as of Sep 11/2015
+	DataCenterEnabled		bool			`json: "dataCenterEnabled"`
+	ImportVMEnabled			bool			`json: "importVMEnabled"`
 }
 
 type DeployableNetworks struct {
-	Name      string
-	NetworkId string
-	Type      string
-	AccountID string
+	// User-defined name of the network
+	Name		string	`json: "name"`
+
+	// Unique identifier of the network
+	NetworkId	string	`json: "networkId"`
+
+	// Network type, usually "private" for networks created by the user
+	Type		string	`json: "type"`
+
+	// Account alias for the account in which the network exists
+	AccountID	string	`json: "accoundID"`
 }
 
 type Templates struct {
-	Name               string
-	Description        string
-	StorageSizeGB      int
-	Capabilities       []string
-	ReservedDrivePaths []string
-	DrivePathLength    int
+	// Underlying unique name for the template
+	Name			string		`json: "name"`
+
+	// FIXME: undocumented as of Sep 11/2015
+	OsType			string		`json: "osType"`
+
+	// Description of the template at it appears in the Control Portal UI
+	Description		string		`json: "description"`
+
+	// The amount of storage allocated for the primary OS root drive
+	StorageSizeGB		int		`json: "storageSizeGB"`
+
+	// List of capabilities supported by this specific OS template
+	// (example: whether adding CPU or memory requires a reboot or not)
+	Capabilities		[]string	`json: "capabilities"`
+
+	// List of drive path names reserved by the OS that can't be used
+	// to name user-defined drives. For example:
+	// Linux:   bin, boot, build, cdrom, etc, home, initrd.img, lib, lib64, libexec, lost+found ...
+	// Windows: a, b, c, d,
+	ReservedDrivePaths	[]string	`json: "reservedDrivePaths"`
+
+	// Length of the string for naming a drive path, if applicable. For examle:
+	// Linux:   0
+	// Windows: 1
+	DrivePathLength		int		`json: "drivePathLength"`
+}
+
+// FIXME: there is no online description for this yet as of Sep 11/2015
+type ImportableOsType struct {
+	Type			string	`json: "type"`
+	Description		string	`json: "description"`
+	Id			int	`json: "id"`
+	LabProductCode		string	`json: "labProductCode"`
+	PremiumProductCode	string	`json: "premiumProductCode"`
 }

--- a/models/datacenters/get_datacenter_group.go
+++ b/models/datacenters/get_datacenter_group.go
@@ -3,6 +3,7 @@ package datacenters
 import (
 	"github.com/s-matyukevich/centurylink_sdk/base"
 	"github.com/s-matyukevich/centurylink_sdk/models"
+	"github.com/s-matyukevich/centurylink_sdk/models/groups"
 )
 
 type GetDatacenterGroupRes struct {
@@ -27,11 +28,13 @@ func (r *GetDatacenterGroupRes) SetConnection(connection base.Connection) {
 }
 
 func (r *GetDatacenterGroupRes) Self() (res *GetDatacenterGroupRes, err error) {
+	res = &GetDatacenterGroupRes{}
 	err = models.ResolveLink(r, "self", "GET", res)
 	return
 }
 
-func (r *GetDatacenterGroupRes) RootGroup() (res *GetDatacenterGroupRes, err error) {
+func (r *GetDatacenterGroupRes) RootGroup() (res *groups.GetGroupRes, err error) {
+	res = &groups.GetGroupRes{}
 	err = models.ResolveLink(r, "group", "GET", res)
 	return
 }

--- a/models/datacenters/get_datacenter_group.go
+++ b/models/datacenters/get_datacenter_group.go
@@ -6,34 +6,33 @@ import (
 	"github.com/s-matyukevich/centurylink_sdk/models/groups"
 )
 
-type GetDatacenterGroupRes struct {
-	Connection base.Connection
-	Id         string
-	Name       string
-	Links      []models.Link
+type GetDatacenterRes struct {
+	// Injected field
+	Connection	base.Connection
+
+	// Short value representing the data center code
+	Id		string		`json: "id"`
+
+	// Full, friendly name of the data center
+	Name		string		`json: "name"`
+
+	// Collection of entity links that point to resources related to this data center
+	Links		[]models.Link	`json: "links"`
 }
 
-var _ models.LinkModel = (*GetDatacenterGroupRes)(nil)
-
-func (r *GetDatacenterGroupRes) GetLinks() []models.Link {
+func (r *GetDatacenterRes) GetLinks() []models.Link {
 	return r.Links
 }
 
-func (r *GetDatacenterGroupRes) GetConnection() base.Connection {
+func (r *GetDatacenterRes) GetConnection() base.Connection {
 	return r.Connection
 }
 
-func (r *GetDatacenterGroupRes) SetConnection(connection base.Connection) {
+func (r *GetDatacenterRes) SetConnection(connection base.Connection) {
 	r.Connection = connection
 }
 
-func (r *GetDatacenterGroupRes) Self() (res *GetDatacenterGroupRes, err error) {
-	res = &GetDatacenterGroupRes{}
-	err = models.ResolveLink(r, "self", "GET", res)
-	return
-}
-
-func (r *GetDatacenterGroupRes) RootGroup() (res *groups.GetGroupRes, err error) {
+func (r *GetDatacenterRes) RootGroup() (res *groups.GetGroupRes, err error) {
 	res = &groups.GetGroupRes{}
 	err = models.ResolveLink(r, "group", "GET", res)
 	return

--- a/models/datacenters/get_datacenter_group.go
+++ b/models/datacenters/get_datacenter_group.go
@@ -27,11 +27,11 @@ func (r *GetDatacenterGroupRes) SetConnection(connection base.Connection) {
 }
 
 func (r *GetDatacenterGroupRes) Self() (res *GetDatacenterGroupRes, err error) {
-	err = models.ResolveLink(r, "self", res)
+	err = models.ResolveLink(r, "self", "GET", res)
 	return
 }
 
 func (r *GetDatacenterGroupRes) RootGroup() (res *GetDatacenterGroupRes, err error) {
-	err = models.ResolveLink(r, "group", res)
+	err = models.ResolveLink(r, "group", "GET", res)
 	return
 }

--- a/models/datacenters/get_datacenter_list.go
+++ b/models/datacenters/get_datacenter_list.go
@@ -27,6 +27,6 @@ func (r *GetDatacenterListRes) SetConnection(connection base.Connection) {
 }
 
 func (r *GetDatacenterListRes) Self() (res *GetDatacenterListRes, err error) {
-	err = models.ResolveLink(r, "self", res)
+	err = models.ResolveLink(r, "self", "GET", res)
 	return
 }

--- a/models/groups/get_group.go
+++ b/models/groups/get_group.go
@@ -6,42 +6,62 @@ import (
 	"github.com/s-matyukevich/centurylink_sdk/models/servers"
 )
 
+/* Group Entity Definition */
+type GetGroupRes struct {
+	// Injected field; to traverse links
+	Connection	base.Connection
+
+	// User-defined name of the group
+	Name		string		`json: "name"`
+
+	// User-defined description of this group
+	Description	string		`json: "description"`
+
+	// ID of the group being queried
+	Id		string		`json: "id"`
+
+	// Data center location identifier
+	LocationId	string		`json: "locationId"`
+	// Group type which could include system types like "archive"
+	Type		string		`json: "type"`
+
+	// Describes if group is online or not (e.g. "active")
+	Status		string		`json: "status"`
+
+	// Number of servers this group contains
+	ServersCount	int		`json: "serversCount"`
+
+	// Refers to this same entity type for each sub-group
+	Groups		[]GetGroupRes	`json: "groups"`
+	// Collection of entity links that point to resources related to this group
+	Links		[]models.Link	`json: "links"`
+	// Describes "created" and "modified" details
+	ChangeInfo	ChangeInfo	`json: "changeInfo"`
+	// Details about any custom fields and their values
+	CustomFields	[]CustomFields	`json: "customFields"`
+}
+
 type ChangeInfo struct {
-	CreatedDate	string
-	CreatedBy	string
-	ModifiedDate	string
-	ModifiedBy	string
+	// Date/time that the group was created (format: "2013-11-22T23:38:50Z")
+	CreatedDate	string	`json: "createdDate"`
+	// Who created the group
+	CreatedBy	string	`json: "createdBy"`
+	// Date/time that the group was last updated (same format as @CreatedDate)
+	ModifiedDate	string	`json: "modifiedDate"`
+	// Who modified the group last
+	ModifiedBy	string	`json: "modifiedBy"`
 }
 
 type CustomFields struct {
-	Id		string
-	Name		string
-	Value		string
-	DisplayValue	string
+	// Unique ID of the custom field
+	Id		string	`json: "id"`
+	// Friendly name of the custom field
+	Name		string	`json: "name"`
+	// Underlying value of the field
+	Value		string	`json: "value"`
+	// Shown value of the field
+	DisplayValue	string	`json: "displayValue"`
 }
-
-type GetGroupRes struct {
-	Connection   base.Connection
-	Id           string
-	Name         string
-	Description  string
-	LocationId   string
-	Type         string
-	Status       string
-	ServersCount int
-	Groups       []GetGroupRes
-	Links        []models.Link
-	ChangeInfo   ChangeInfo
-	CustomFields []CustomFields
-}
-
-type GroupLimits struct {
-	Cpu       int
-	MemoryGB  int
-	StorageGB int
-}
-
-var _ models.LinkModel = (*GetGroupRes)(nil)
 
 func (r *GetGroupRes) GetLinks() []models.Link {
 	return r.Links

--- a/models/groups/get_group.go
+++ b/models/groups/get_group.go
@@ -6,17 +6,33 @@ import (
 	"github.com/s-matyukevich/centurylink_sdk/models/servers"
 )
 
+type ChangeInfo struct {
+	CreatedDate	string
+	CreatedBy	string
+	ModifiedDate	string
+	ModifiedBy	string
+}
+
+type CustomFields struct {
+	Id		string
+	Name		string
+	Value		string
+	DisplayValue	string
+}
+
 type GetGroupRes struct {
 	Connection   base.Connection
 	Id           string
 	Name         string
 	Description  string
+	LocationId   string
 	Type         string
 	Status       string
 	ServersCount int
-	Limits       GroupLimits
 	Groups       []GetGroupRes
 	Links        []models.Link
+	ChangeInfo   ChangeInfo
+	CustomFields []CustomFields
 }
 
 type GroupLimits struct {

--- a/models/groups/get_group.go
+++ b/models/groups/get_group.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/s-matyukevich/centurylink_sdk/base"
 	"github.com/s-matyukevich/centurylink_sdk/models"
-	"github.com/s-matyukevich/centurylink_sdk/models/servers"
 )
 
 /* Group Entity Definition */
@@ -78,22 +77,14 @@ func (r *GetGroupRes) SetConnection(connection base.Connection) {
 	r.Connection = connection
 }
 
-func (r *GetGroupRes) Self() (res *GetGroupRes, err error) {
-	err = models.ResolveLink(r, "self", "GET", res)
-	return
-}
-
 func (r *GetGroupRes) Billing() (res *GetGroupBillingDetailsRes, err error) {
+	res = &GetGroupBillingDetailsRes{Connection: r.Connection}
 	err = models.ResolveLink(r, "billing", "GET", res)
 	return
 }
 
 func (r *GetGroupRes) Statistics() (res *GetGroupMonitoringStatisticsRes, err error) {
+	res = &GetGroupMonitoringStatisticsRes{Connection: r.Connection}
 	err = models.ResolveLink(r, "statistics", "GET", res)
-	return
-}
-
-func (r *GetGroupRes) Server() (res *servers.GetServerRes, err error) {
-	err = models.ResolveLink(r, "server", "GET", res)
 	return
 }

--- a/models/groups/get_group.go
+++ b/models/groups/get_group.go
@@ -1,6 +1,8 @@
 package groups
 
 import (
+	"time"
+
 	"github.com/s-matyukevich/centurylink_sdk/base"
 	"github.com/s-matyukevich/centurylink_sdk/models"
 	"github.com/s-matyukevich/centurylink_sdk/models/servers"
@@ -42,14 +44,15 @@ type GetGroupRes struct {
 }
 
 type ChangeInfo struct {
-	// Date/time that the group was created (format: "2013-11-22T23:38:50Z")
-	CreatedDate	string	`json: "createdDate"`
+	// Date/time that the group was created (format: "2013-11-22T23:38:50Z", which
+	// is compatible with RFC3339 format used by what the time package marshals).
+	CreatedDate	time.Time	`json: "createdDate"`
 	// Who created the group
-	CreatedBy	string	`json: "createdBy"`
+	CreatedBy	string		`json: "createdBy"`
 	// Date/time that the group was last updated (same format as @CreatedDate)
-	ModifiedDate	string	`json: "modifiedDate"`
+	ModifiedDate	time.Time	`json: "modifiedDate"`
 	// Who modified the group last
-	ModifiedBy	string	`json: "modifiedBy"`
+	ModifiedBy	string		`json: "modifiedBy"`
 }
 
 type CustomFields struct {

--- a/models/groups/get_group.go
+++ b/models/groups/get_group.go
@@ -40,21 +40,21 @@ func (r *GetGroupRes) SetConnection(connection base.Connection) {
 }
 
 func (r *GetGroupRes) Self() (res *GetGroupRes, err error) {
-	err = models.ResolveLink(r, "self", res)
+	err = models.ResolveLink(r, "self", "GET", res)
 	return
 }
 
 func (r *GetGroupRes) Billing() (res *GetGroupBillingDetailsRes, err error) {
-	err = models.ResolveLink(r, "billing", res)
+	err = models.ResolveLink(r, "billing", "GET", res)
 	return
 }
 
 func (r *GetGroupRes) Statistics() (res *GetGroupMonitoringStatisticsRes, err error) {
-	err = models.ResolveLink(r, "statistics", res)
+	err = models.ResolveLink(r, "statistics", "GET", res)
 	return
 }
 
 func (r *GetGroupRes) Server() (res *servers.GetServerRes, err error) {
-	err = models.ResolveLink(r, "server", res)
+	err = models.ResolveLink(r, "server", "GET", res)
 	return
 }

--- a/models/groups/get_group_billing_details.go
+++ b/models/groups/get_group_billing_details.go
@@ -2,9 +2,13 @@ package groups
 
 import (
 	"time"
+	"github.com/s-matyukevich/centurylink_sdk/base"
 )
 
 type GetGroupBillingDetailsRes struct {
+	// Injected field; to traverse links
+	Connection	base.Connection
+
 	Date   time.Time
 	Groups map[string]GroupDef
 }

--- a/models/groups/get_group_monitoring_statistics.go
+++ b/models/groups/get_group_monitoring_statistics.go
@@ -2,9 +2,13 @@ package groups
 
 import (
 	"time"
+	"github.com/s-matyukevich/centurylink_sdk/base"
 )
 
 type GetGroupMonitoringStatisticsRes struct {
+	// Injected field; to traverse links
+	Connection	base.Connection
+
 	Name  string
 	Stats []StatsDef
 }

--- a/models/link.go
+++ b/models/link.go
@@ -1,9 +1,9 @@
 package models
 
 type Link struct {
-	Rel  string
-	Href string
-	Id   string
-	Name string
-	Verb string
+	Rel   string
+	Href  string
+	Id    string
+	Name  string
+	Verbs []string
 }

--- a/models/link_resolver.go
+++ b/models/link_resolver.go
@@ -15,15 +15,30 @@ func getLink(linkModel LinkModel, linkRel string) (res Link, err error) {
 	return
 }
 
-func ResolveLink(model LinkModel, linkRel string, resModel interface{}) (err error) {
+func checkVerb(link Link, verb string) bool {
+	if len(link.Verbs) == 0 {
+		return verb == "GET"
+	}
+	for _, v := range link.Verbs {
+		if v == verb {
+			return true
+		}
+	}
+	return false
+}
+
+func ResolveLink(model LinkModel, linkRel string, verb string, resModel interface{}) (err error) {
 	link, err := getLink(model, linkRel)
 	if err != nil {
 		return
 	}
-	verb := "GET"
-	if link.Verb != "" {
-		verb = link.Verb
+
+	if !checkVerb(link, verb) {
+		err = fmt.Errorf("There is no support for verb %s in link rel %q of model %T",
+				 verb, link.Rel, model)
+		return
 	}
+
 	cn := model.GetConnection()
 	if cn == nil {
 		err = fmt.Errorf("Model connection is not initialized.")

--- a/models/link_resolver_test.go
+++ b/models/link_resolver_test.go
@@ -19,8 +19,6 @@ type TestModelRes struct {
 	Links      []Link
 }
 
-var _ LinkModel = (*TestModelRes)(nil)
-
 func (r *TestModelRes) GetLinks() []Link {
 	return r.Links
 }

--- a/models/link_resolver_test.go
+++ b/models/link_resolver_test.go
@@ -59,13 +59,15 @@ func (s *LinkResolverSuite) TestResolveLink(c *gc.C) {
 	model := &TestModelRes{
 		Links: []Link{Link{Rel: "self"}, Link{Rel: "parent"}},
 	}
-	err := ResolveLink(model, "self", nil)
-
+	err := ResolveLink(model, "self", "GET", nil)
 	c.Check(err, gc.ErrorMatches, "Model connection is not initialized.")
+
 	model.Connection = &fakeConnection{C: c, verb: "GET"}
-	err = ResolveLink(model, "self", nil)
+	err = ResolveLink(model, "self", "GET", nil)
+	c.Check(err, gc.IsNil)
 
 	model.Connection = &fakeConnection{C: c, verb: "POST"}
-	model.Links[0].Verb = "POST"
-	err = ResolveLink(model, "self", nil)
+	model.Links[0].Verbs = []string{"POST"}
+	err = ResolveLink(model, "self", "POST", nil)
+	c.Check(err, gc.IsNil)
 }

--- a/models/servers/create_server.go
+++ b/models/servers/create_server.go
@@ -5,31 +5,29 @@ import (
 )
 
 type CreateServerReq struct {
-	Nane                 string
-	Description          string
-	GroupId              string
-	SourceServerId       string
-	IsManagedOS          bool
-	PrimaryDns           string
-	SecondaryDns         string
-	IpAddress            string
-	Password             string
-	SourceServerPassword string
-	Cpu                  int
-	CpuAutoscalePolicyId string
-	MemoryGB             int
-	Type                 string
-	StorageType          string
-	AntiAffinityPolicyId string
-	CustomFields         []CustomFieldDef
-	AdditionalDisks      []AdditionalDiskDef
-	Ttl                  time.Time
-	Packages             []PackageDef
-}
-
-type CustomFieldDef struct {
-	Id    string
-	Value string
+	Name			string
+	Description		string
+	GroupId			string
+	SourceServerId		string
+	IsManagedOS		bool
+	PrimaryDns		string
+	SecondaryDns		string
+	IpAddress		string
+	Password		string
+	SourceServerPassword	string
+	Cpu			int
+	CpuAutoscalePolicyId	string
+	MemoryGB		int
+	Type			string
+	StorageType		string
+	AntiAffinityPolicyId	string
+	CustomFields		[]struct {
+					Id    string
+					Value string
+				}
+	AdditionalDisks		[]AdditionalDiskDef
+	Ttl			time.Time
+	Packages		[]PackageDef
 }
 
 type AdditionalDiskDef struct {

--- a/models/servers/get_server.go
+++ b/models/servers/get_server.go
@@ -82,6 +82,6 @@ func (r *GetServerRes) SetConnection(connection base.Connection) {
 }
 
 func (r *GetServerRes) Self() (res *GetServerRes, err error) {
-	err = models.ResolveLink(r, "self", res)
+	err = models.ResolveLink(r, "self", "GET", res)
 	return
 }

--- a/models/servers/get_server.go
+++ b/models/servers/get_server.go
@@ -1,73 +1,164 @@
 package servers
 
 import (
+	"time"
+
 	"github.com/s-matyukevich/centurylink_sdk/base"
 	"github.com/s-matyukevich/centurylink_sdk/models"
-	"time"
 )
 
 type GetServerRes struct {
+	// Injected field; to traverse links
 	Connection  base.Connection
-	Id          string
-	Name        string
-	Description string
-	GroupId     string
-	IsTemplate  bool
-	LocationId  string
-	OsType      string
-	Status      string
-	Details     DetailsDef
-	Type        string
-	StorageType string
-	ChangeInfo  ChangeInfoDef
-	Links       []models.Link
+
+	// ID of the server
+	Id		string		`json: "id"`
+
+	// Name of the server
+	Name        	string		`json: "name"`
+
+	// User-defined description of this server
+	Description	string		`json: "description"`
+
+	// ID of the parent group
+	GroupId     	string		`json: "groupId"`
+
+	// Boolean indicating whether this is a custom template or running server
+	IsTemplate  	bool		`json: "isTemplate"`
+
+	// Data center that this server resides in
+	LocationId  	string		`json: "locationId"`
+
+	// Friendly name of the Operating System the server is running
+	OsType      	string		`json: "osType"`
+
+	// Describes whether the server is active or not
+	Status      	string		`json: "status"`
+
+	// Resource allocations, alert policies, snapshots, and more.
+	Details     	DetailsDef	`json: "details"`
+
+	// Whether a standard or premium server
+	Type        	string		`json: "type"`
+
+	// Whether it uses standard or premium storage
+	StorageType	string		`json: "storageType"`
+
+	// Describes "created" and "modified" details
+	ChangeInfo	ChangeInfoDef	`json: "changeInfo"`
+
+	// Collection of entity links that point to resources related to this server
+	Links		[]models.Link	`json: "links"`
 }
 
 type DetailsDef struct {
-	IpAddresses       []IpAddressDef
-	AlertPolicies     []AlertPolicyDef
-	Cpu               int
-	DiskCount         int
-	HostName          string
-	InMaintenanceMode bool
-	MemoryMB          int
-	PowerState        string
-	StorageGB         int
-	Snapshots         []SnapshotsDef
-	CustomFields      []CustomFieldDef
+	// Details about IP addresses associated with the server
+	IpAddresses       	[]IpAddressDef		`json: "ipAddresses"`
+
+	// Describe each alert policy applied to the server
+	AlertPolicies     	[]AlertPolicyDef	`json: "alertPolicies"`
+
+	// How many vCPUs are allocated to the server
+	Cpu               	int			`json: "cpu"`
+
+	// How many disks are attached to the server
+	DiskCount         	int			`json: "diskCount"`
+
+	// Fully qualified name of the server
+	HostName          	string			`json: "hostName"`
+
+	// Indicator of whether server has been placed in maintenance mode
+	InMaintenanceMode	bool			`json: "inMaintenanceMode"`
+
+	// How many MB of memory are allocated to the server
+	MemoryMB          	int			`json: "memoryMB"`
+
+	// Whether the server is running or not
+	PowerState        	string			`json: "powerState"`
+
+	// How many total GB of storage are allocated to the server
+	StorageGB         	int			`json: "storageGB"`
+
+	// The disks attached to the server
+	Disks			[]DiskDef		`json: "disks"`
+
+	// The partitions defined for the server
+	Partitions		[]PartitionDef		`json: "partitions"`
+
+	// Details about any snapshot associated with the server
+	Snapshots         	[]SnapshotDef		`json: "snapshots"`
+
+	// Details about any custom fields and their values
+	CustomFields      	[]CustomFieldDef	`json: "customFields"`
+
+	// Processor configuration description (for bare metal servers only)
+	ProcessorDescription   	string			`json: "processorDescription"`
+	// Storage configuration description (for bare metal servers only)
+	StorageDescription   	string			`json: "storageDescription"`
 }
 
 type IpAddressDef struct {
-	Public   string
-	Internal string
+	// If applicable, the public IP
+	Public		string	`json: "public"`
+	// Private IP address. If associated with a public IP address, then the "public" value is populated
+	Internal	string	`json: "internal"`
 }
 
 type AlertPolicyDef struct {
-	Id    string
-	Name  string
-	Links []models.Link
+	// Unique identifier of the policy
+	Id	string		`json: "id"`
+	// User-defined name of the alert policy
+	Name	string		`json: "name"`
+	// Collection of entity links that point to resources related to this policy
+	Links	[]models.Link	`json: "links"`
 }
 
-type SnapshotsDef struct {
-	Name  string
-	Links []models.Link
+type DiskDef struct {
+	// Unique identifier of the disk
+	Id		string		`json: "id"`
+	// Size of the disk in GB
+	SizeGB		string		`json: "sizeGB"`
+	// List of partition paths on the disk
+	PartitionPaths	[]string	`json: "partitionPaths"`
 }
 
-type CustomFieldsDef struct {
-	Id           string
-	Name         string
-	Value        string
-	DisplayValue string
+type PartitionDef struct {
+	// Size of the partition in GB
+	SizeGB	string	`json: "sizeGB"`
+	// List of partition paths on the disk
+	Path	string	`json: "path"`
 }
 
+type SnapshotDef struct {
+	// Timestamp of the snapshot
+	Name  string		`json: "name"`
+	// Collection of entity links that point to resources related to this snapshot
+	Links []models.Link	`json: "links"`
+}
+
+// Note: this struct is also used elsewhere
+type CustomFieldDef struct {
+	// Unique ID of the custom field
+	Id           string	`json: "id"`
+	// Friendly name of the custom field
+	Name         string	`json: "name"`
+	// Underlying value of the field
+	Value        string	`json: "value"`
+	// Shown value of the field
+	DisplayValue string	`json: "displayValue"`
+}
+
+// Note: this struct is also used elsewhere
 type ChangeInfoDef struct {
-	CreatedDate  time.Time
-	CreatedBy    string
-	ModifiedDate time.Time
-	ModifiedBy   string
+	// Date/time that the server was created
+	CreatedDate  time.Time	`json: "createdDate"`
+	// Who created the server
+	CreatedBy    string	`json: "createdBy"`
+	// Date/time that the server was last updated
+	ModifiedDate time.Time	`json: "modifiedDate"`
+	// Who modified the server last
+	ModifiedBy   string	`json: "modifiedBy"`
 }
-
-var _ models.LinkModel = (*GetServerRes)(nil)
 
 func (r *GetServerRes) GetLinks() []models.Link {
 	return r.Links

--- a/models/servers/server_res.go
+++ b/models/servers/server_res.go
@@ -29,6 +29,6 @@ func (r *ServerRes) SetConnection(connection base.Connection) {
 }
 
 func (r *ServerRes) Status() (res *queue.GetStatusRes, err error) {
-	err = models.ResolveLink(r, "status", res)
+	err = models.ResolveLink(r, "status", "GET", res)
 	return
 }


### PR DESCRIPTION
Oct 30 - Please ignore pull request; switched to other codebase.

Mostly minor, the one `acctAlias` would have caused an issue.

Please note - the files also have the same spelling. I did not add this since it would have made the diff difficult to read. It can be easily done (tested) in bash like this:

```
git mv models/account/anti_af{,f}inity_policy_res.go 
git mv models/account/create_anti_af{,f}inity_policy.go
git mv models/account/update_anti_af{,f}inity_policy.go
git mv models/servers/get_publi{c,}k_ip_address.go
```
